### PR TITLE
Sleepwatcher configuration tweaks

### DIFF
--- a/ansible/roles/sleepwatcher/tasks/main.yml
+++ b/ansible/roles/sleepwatcher/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Create SleepWatcher Log Directory
   file:
-    path: "{{ sleepwatcher.log | dirname }}"
+    path: "{{ sleepwatcher.log_file | dirname }}"
     state: directory
     mode: 0751
   tags:
@@ -33,7 +33,7 @@
 
 - name: Create SleepWatcher Log File
   file:
-    path: "{{ sleepwatcher.log }}"
+    path: "{{ sleepwatcher.log_file }}"
     state: touch
     mode: 0644
   tags:

--- a/ansible/roles/sleepwatcher/templates/.sleep.j2
+++ b/ansible/roles/sleepwatcher/templates/.sleep.j2
@@ -1,7 +1,6 @@
 #!/bin/bash
-/usr/sbin/networksetup setairportpower en0 off
+LOG_FILE="{{ sleepwatcher.log }}"
 
-echo -n > {{ sleepwatcher.log }}
-
-echo "Sleeping: `date`" >> {{ sleepwatcher.log }}
-echo `/usr/sbin/networksetup getairportpower en0` >> {{ sleepwatcher.log }}
+echo "[`date`] Sleeping Networking" >> $LOG_FILE
+/usr/sbin/networksetup setairportpower en0 off >> $LOG_FILE
+echo `/usr/sbin/networksetup getairportpower en0` >> $LOG_FILE

--- a/ansible/roles/sleepwatcher/templates/.wakeup.j2
+++ b/ansible/roles/sleepwatcher/templates/.wakeup.j2
@@ -1,6 +1,10 @@
 #!/bin/bash
-sleep {{ sleepwatcher.wakeup_delay }}
-/usr/sbin/networksetup setairportpower en0 on
+DELAY={{ sleepwatcher.wakeup_delay }}
+LOG_FILE="{{ sleepwatcher.log_file }}"
 
-echo "Waking Up: `date`" >> {{ sleepwatcher.log }}
-echo `/usr/sbin/networksetup getairportpower en0` >> {{ sleepwatcher.log }}
+echo "[`date`] Waiting $DELAY Seconds" >> $LOG_FILE
+sleep $DELAY
+
+echo "[`date`] Waking Up Networking" >> $LOG_FILE
+/usr/sbin/networksetup setairportpower en0 on >> $LOG_FILE
+echo `/usr/sbin/networksetup getairportpower en0` >> $LOG_FILE

--- a/ansible/roles/sleepwatcher/vars/main.yml
+++ b/ansible/roles/sleepwatcher/vars/main.yml
@@ -1,4 +1,4 @@
 ---
 sleepwatcher:
   wakeup_delay: 5
-  log: ~/Library/Logs/SleepWatcher/sleep.log
+  log_file: "{{ lookup('env','HOME') }}/Library/Logs/SleepWatcher/sleepwatcher.log"


### PR DESCRIPTION
- Change log file name.
- Ensure path is appended to `$HOME`.
- Simplify scripts.
- Clean up output formatting.