### PR TITLE
ZSH Clean Up

### DIFF
--- a/ansible/roles/shell/files/.zsh_aliases
+++ b/ansible/roles/shell/files/.zsh_aliases
@@ -57,9 +57,5 @@ alias edithosts="${EDITOR} /etc/hosts"
 # Empty Filebot history file and logs
 alias emptyfilebot="rm -f ~/.filebot/history.xml && rm -f ~/.filebot/error.log"
 
-# Encrypt/descrypt files quickly
-alias decrypt="openssl enc -d -aes-256-cbc -md sha512 -pbkdf2 -iter 1000000 -in $1 -out $2"
-alias encrypt="openssl enc -aes-256-cbc -md sha512 -pbkdf2 -iter 1000000 -salt -in $1 -out $2"
-
 # Laravel Sail shortcut
 alias sail='[ -f sail ] && zsh sail || zsh vendor/bin/sail'

--- a/ansible/roles/shell/files/.zsh_aliases
+++ b/ansible/roles/shell/files/.zsh_aliases
@@ -1,39 +1,12 @@
-# Easier navigation: .., ..., ...., ....., ~ and -
+# Slightly quicker directory navigation
 alias ..="cd .."
-alias ...="cd ../.."
-alias ....="cd ../../.."
-alias .....="cd ../../../.."
-alias ~="cd ~" # `cd` is probably faster to type though
-alias -- -="cd -"
+alias ~="cd ~"
 
-# Detect which `ls` flavor is in use
-if ls --color > /dev/null 2>&1; then # GNU `ls`
-	colorflag="--color"
-else # OS X `ls`
-	colorflag="-G"
-fi
-
-# List all files colorized in long format
-alias l="ls -lF ${colorflag}"
-
-# List all files colorized in long format, including dot files
-alias la="ls -laF ${colorflag}"
-
-# List only directories
-alias lsd="ls -lF ${colorflag} | grep --color=never '^d'"
-
-# Always use color output for `ls`
-alias ls="command ls ${colorflag}"
-export LS_COLORS='no=00:fi=00:di=01;34:ln=01;36:pi=40;33:so=01;35:do=01;35:bd=40;33;01:cd=40;33;01:or=40;31;01:ex=01;32:*.tar=01;31:*.tgz=01;31:*.arj=01;31:*.taz=01;31:*.lzh=01;31:*.zip=01;31:*.z=01;31:*.Z=01;31:*.gz=01;31:*.bz2=01;31:*.deb=01;31:*.rpm=01;31:*.jar=01;31:*.jpg=01;35:*.jpeg=01;35:*.gif=01;35:*.bmp=01;35:*.pbm=01;35:*.pgm=01;35:*.ppm=01;35:*.tga=01;35:*.xbm=01;35:*.xpm=01;35:*.tif=01;35:*.tiff=01;35:*.png=01;35:*.mov=01;35:*.mpg=01;35:*.mpeg=01;35:*.avi=01;35:*.fli=01;35:*.gl=01;35:*.dl=01;35:*.xcf=01;35:*.xwd=01;35:*.ogg=01;35:*.mp3=01;35:*.wav=01;35:'
+# Always use color output for `ls`, add slashes to directories and put highlight executables
+alias ls="ls -GpF"
 
 # Enable aliases to be sudo’ed
 alias sudo='sudo '
-
-# Get week number
-alias week='date +%V'
-
-# Stopwatch
-alias timer='echo "Timer started. Stop with Ctrl-D." && date && time cat && date'
 
 # IP addresses
 alias ip="dig +short myip.opendns.com @resolver1.opendns.com"
@@ -41,65 +14,48 @@ alias localip="ipconfig getifaddr en0"
 alias ips="ifconfig -a | grep -o 'inet6\? \(addr:\)\?\s\?\(\(\([0-9]\+\.\)\{3\}[0-9]\+\)\|[a-fA-F0-9:]\+\)' | awk '{ sub(/inet6? (addr:)? ?/, \"\"); print }'"
 
 # Flush Directory Service cache
-alias flush="dscacheutil -flushcache && killall -HUP mDNSResponder"
-alias reloadhosts="flush"
+alias reloadhosts="dscacheutil -flushcache && killall -HUP mDNSResponder"
 
-# Clean up LaunchServices to remove duplicates in the “Open With” menu
-alias lscleanup="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -kill -r -domain local -domain system -domain user && killall Finder"
+# Get the hex dump of a file (some systems have this symlinked)
+command -v hexdump > /dev/null || alias hd="hexdump -C"
 
-# View HTTP traffic
-alias sniff="sudo ngrep -d 'en1' -t '^(GET|POST) ' 'tcp and port 80'"
-alias httpdump="sudo tcpdump -i en1 -n -s 0 -w - | grep -a -o -E \"Host\: .*|GET \/.*\""
-
-# Canonical hex dump; some systems have this symlinked
-command -v hd > /dev/null || alias hd="hexdump -C"
-
-# OS X has no `md5sum`, so use `md5` as a fallback
+# Get the md5 checksum of a file (macOS does not have `md5sum`)
 command -v md5sum > /dev/null || alias md5sum="md5"
 
-# OS X has no `sha1sum`, so use `shasum` as a fallback
+# Get the sha1 checksum of a file (macOS does not have `sha1sum`)
 command -v sha1sum > /dev/null || alias sha1sum="shasum"
 
 # Recursively delete `.DS_Store` files
 alias cleanupds="find . -type f -name '*.DS_Store' -ls -delete"
 
-# Empty the Trash on all mounted volumes and the main HDD
-# Also, clear Apple’s System Logs to improve shell startup speed
-alias emptytrash="sudo rm -rfv /Volumes/*/.Trashes; sudo rm -rfv ~/.Trash; sudo rm -rfv /private/var/log/asl/*.asl"
+# Empty the Trash on the hard disk and all mounted volumes
+alias emptytrash="sudo rm -rfv /Volumes/*/.Trashes; sudo rm -rfv ~/.Trash"
 
-# Show/hide hidden files in Finder
+# Empty Apple’s system logs to improve shell startup speed
+alias emptysystemlogs="sudo rm -rfv /private/var/log/asl/*.asl"
+
+# Show/hide hidden files in Finder or use (CMD + Shift + .)
 alias showhidden="defaults write com.apple.finder AppleShowAllFiles -bool true && killall Finder"
 alias hidehidden="defaults write com.apple.finder AppleShowAllFiles -bool false && killall Finder"
 
-# URL-encode strings
-alias urlencode='python -c "import sys, urllib as ul; print ul.quote_plus(sys.argv[1]);"'
+# Merge PDF files together
+# @see: https://apple.stackexchange.com/questions/230437/how-can-i-combine-multiple-pdfs-using-the-command-line/230447#230447
+alias mergepdfs='/System/Library/Automator/Combine PDF Pages.action/Contents/MacOS/join'
 
-# Merge PDF files
-# Usage: `mergepdf -o output.pdf input{1,2,3}.pdf`
-alias mergepdf='/System/Library/Automator/Combine\ PDF\ Pages.action/Contents/Resources/join.py'
-
-# Ring the terminal bell, and put a badge on Terminal.app’s Dock icon
-# (useful when executing time-consuming commands)
+# Ring the terminal bell and put a badge on Terminal app's Dock icon (useful when executing time-consuming commands)
 alias badge="tput bel"
-
-# Lock the screen (when going AFK)
-alias afk="/System/Library/CoreServices/Menu\ Extras/User.menu/Contents/Resources/CGSession -suspend"
 
 # Reload the shell (i.e. invoke as a login shell)
 alias reloadshell="exec $SHELL -l"
-alias reload="reloadshell"
 
 # Open up the bash profile for editing
-alias editbash="${EDITOR} ~/.bash_profile"
+alias editshell="${EDITOR} ~/.zshrc"
 
 # Open up the hosts file for editing
 alias edithosts="${EDITOR} /etc/hosts"
 
-# Empty Filebot history file
+# Empty Filebot history file and logs
 alias emptyfilebot="rm -f ~/.filebot/history.xml && rm -f ~/.filebot/error.log"
 
-# VLC shortcut
-alias vlc="/Applications/VLC.app/Contents/MacOS/VLC"
-
-# Laravel Sail
+# Laravel Sail shortcut
 alias sail='[ -f sail ] && zsh sail || zsh vendor/bin/sail'

--- a/ansible/roles/shell/files/.zsh_aliases
+++ b/ansible/roles/shell/files/.zsh_aliases
@@ -56,6 +56,3 @@ alias edithosts="${EDITOR} /etc/hosts"
 
 # Empty Filebot history file and logs
 alias emptyfilebot="rm -f ~/.filebot/history.xml && rm -f ~/.filebot/error.log"
-
-# Laravel Sail shortcut
-alias sail='[ -f sail ] && zsh sail || zsh vendor/bin/sail'

--- a/ansible/roles/shell/files/.zsh_aliases
+++ b/ansible/roles/shell/files/.zsh_aliases
@@ -57,5 +57,9 @@ alias edithosts="${EDITOR} /etc/hosts"
 # Empty Filebot history file and logs
 alias emptyfilebot="rm -f ~/.filebot/history.xml && rm -f ~/.filebot/error.log"
 
+# Encrypt/descrypt files quickly
+alias decrypt="openssl enc -d -aes-256-cbc -md sha512 -pbkdf2 -iter 1000000 -in $1 -out $2"
+alias encrypt="openssl enc -aes-256-cbc -md sha512 -pbkdf2 -iter 1000000 -salt -in $1 -out $2"
+
 # Laravel Sail shortcut
 alias sail='[ -f sail ] && zsh sail || zsh vendor/bin/sail'

--- a/ansible/roles/shell/files/.zsh_exports
+++ b/ansible/roles/shell/files/.zsh_exports
@@ -1,16 +1,12 @@
 # Preferred editor for local and remote sessions
-if [[ -n $SSH_CONNECTION ]]; then
-  export EDITOR='nano'
-else
-  export EDITOR='nano'
-fi
+export EDITOR='nano'
 
 # Ignore specific commands from history.
-# https://stackoverflow.com/questions/38549251/histignore-not-working-in-zsh
+# @see: https://stackoverflow.com/questions/38549251/histignore-not-working-in-zsh
 export HISTORY_IGNORE="(media-swapper*)"
 
 # Remove duplicate commands from history.
-# https://unix.stackexchange.com/questions/599641/why-do-i-have-duplicates-in-my-zsh-history
+# @see: https://unix.stackexchange.com/questions/599641/why-do-i-have-duplicates-in-my-zsh-history
 setopt HIST_IGNORE_DUPS
 
 # Prefer US English and use UTF-8.
@@ -19,7 +15,7 @@ export LANGUAGE='en_US:en';
 export LC_ALL='en_US.UTF-8';
 
 # Composer OAuth
-# https://www.previousnext.com.au/blog/managing-composer-github-access-personal-access-tokens
+# @see: https://www.previousnext.com.au/blog/managing-composer-github-access-personal-access-tokens
 # export COMPOSER_AUTH='{"github-oauth": {"github.com": "xxx"}}'
 
 # Disable Homebrew analytics

--- a/ansible/roles/shell/files/.zsh_exports
+++ b/ansible/roles/shell/files/.zsh_exports
@@ -3,7 +3,7 @@ export EDITOR='nano'
 
 # Ignore specific commands from history.
 # @see: https://stackoverflow.com/questions/38549251/histignore-not-working-in-zsh
-export HISTORY_IGNORE="(media-swapper*|ente-decrypt*)"
+export HISTORY_IGNORE="(media-swapper*)"
 
 # Remove duplicate commands from history.
 # @see: https://unix.stackexchange.com/questions/599641/why-do-i-have-duplicates-in-my-zsh-history

--- a/ansible/roles/shell/files/.zsh_exports
+++ b/ansible/roles/shell/files/.zsh_exports
@@ -3,7 +3,7 @@ export EDITOR='nano'
 
 # Ignore specific commands from history.
 # @see: https://stackoverflow.com/questions/38549251/histignore-not-working-in-zsh
-export HISTORY_IGNORE="(media-swapper*)"
+export HISTORY_IGNORE="(media-swapper*|ente-decrypt*)"
 
 # Remove duplicate commands from history.
 # @see: https://unix.stackexchange.com/questions/599641/why-do-i-have-duplicates-in-my-zsh-history

--- a/ansible/roles/shell/files/.zsh_functions
+++ b/ansible/roles/shell/files/.zsh_functions
@@ -62,5 +62,5 @@ function syncvault() {
     rsync --archive --compress --progress --verbose --quiet "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Users/Jamie/Library/Mobile Documents/com~apple~CloudDocs/1Password/"
 
     echo "Backing up 1Password to NAS..."
-    rsync --archive --compress --progress --verbose --quiet "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Volumes/files/Backups/1Password/Latest/"
+    rsync --archive --compress --progress --verbose --quiet "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Volumes/files/Backups/1Password/"
 }

--- a/ansible/roles/shell/files/.zsh_functions
+++ b/ansible/roles/shell/files/.zsh_functions
@@ -57,16 +57,10 @@ singlefile() {
 }
 
 # Sync 1Password 7 Vault
-# Automatic Snapshots Directory: /Users/Jamie/Library/Group Containers/2BUA8C4S2C.com.agilebits/Library/Application Support/1Password/Backups
 function syncvault() {
     echo "Backing up 1Password to iCloud..."
     rsync --archive --compress --progress --verbose --quiet "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Users/Jamie/Library/Mobile Documents/com~apple~CloudDocs/1Password/"
 
-    echo "Rotating 1Password on NAS..."
-    mkdir -p "/Volumes/files/Backups/1Password/Backups"
-    rsync --archive --compress --progress --verbose --quiet "/Volumes/files/Backups/1Password/Latest/1Password.opvault" "/Volumes/files/Backups/1Password/Backups/1Password-$(date +%F).opvault"
-
     echo "Backing up 1Password to NAS..."
     rsync --archive --compress --progress --verbose --quiet "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Volumes/files/Backups/1Password/Latest/"
 }
-

--- a/ansible/roles/shell/files/.zsh_functions
+++ b/ansible/roles/shell/files/.zsh_functions
@@ -62,6 +62,6 @@ function syncvault() {
     rsync --archive --compress --progress --verbose "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Users/Jamie/Library/Mobile Documents/com~apple~CloudDocs/1Password/"
 
     # Sync Backups to NAS:
-    rsync --archive --compress --progress --verbose "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Volumes/files/Backups/1Password/"
-    rsync --recursive --times --update --compress --progress --verbose "/Users/Jamie/Library/Group Containers/2BUA8C4S2C.com.agilebits/Library/Application Support/1Password/Backups/" "/Volumes/files/Backups/1Password/"
+    rsync --archive --compress --progress --verbose "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Volumes/files/Backups/1Password/Latest/"
+    rsync --recursive --times --update --compress --progress --verbose "/Users/Jamie/Library/Group Containers/2BUA8C4S2C.com.agilebits/Library/Application Support/1Password/Backups/" "/Volumes/files/Backups/1Password/Snapshots/"
 }

--- a/ansible/roles/shell/files/.zsh_functions
+++ b/ansible/roles/shell/files/.zsh_functions
@@ -1,4 +1,4 @@
-# Extract based upon file ext
+# Extract compressed file based upon its extension
 function extract() {
     if [ -f $1 ]; then
         case $1 in
@@ -21,7 +21,7 @@ function extract() {
 }
 
 # Regenerate MAC address
-# http://jezenthomas.com/free-internet-on-trains/
+# @see: http://jezenthomas.com/free-internet-on-trains/
 remac() {
     sudo /System/Library/PrivateFrameworks/Apple80211.framework/Resources/airport -z
     sudo ifconfig en0 ether $(openssl rand -hex 6 | sed 's/\(..\)/\1:/g; s/.$//')
@@ -30,11 +30,11 @@ remac() {
 }
 
 # Set DNS servers
-# http://osxdaily.com/2015/06/02/change-dns-command-line-mac-os-x/
-# http://osxdaily.com/2014/09/03/list-all-network-hardware-from-the-command-line-in-os-x/
-# https://superuser.com/questions/86184/change-dns-server-from-terminal-or-script-on-mac-os-x
-# https://superuser.com/questions/258151/how-do-i-check-what-dns-server-im-using-on-mac-os-x
-setdnsservers() {
+# @see: http://osxdaily.com/2015/06/02/change-dns-command-line-mac-os-x/
+# @see: http://osxdaily.com/2014/09/03/list-all-network-hardware-from-the-command-line-in-os-x/
+# @see: https://superuser.com/questions/86184/change-dns-server-from-terminal-or-script-on-mac-os-x
+# @see: https://superuser.com/questions/258151/how-do-i-check-what-dns-server-im-using-on-mac-os-x
+setdns() {
     local dns_servers="${*:-192.168.0.3 1.1.1.1 1.0.0.1}"
     if [ "$(networksetup -getdnsservers Wi-Fi | tr '\n' ' ' | xargs)" != "$dns_servers" ]; then
         sudo networksetup -setdnsservers Wi-Fi empty
@@ -45,38 +45,13 @@ setdnsservers() {
     fi
 }
 
-# Display a weather forecast
-weather() {
-    local location=${1:-London}
-    local lang=${2:-en}
 
-    curl -s "wttr.in/$location?lang=$lang"
-}
-
-# Kill process listening on a specific port
-# https://stackoverflow.com/questions/33615683/how-to-access-the-pid-from-an-lsof
-function killport() {
-    lsof -t -i:$1 | xargs kill -9
-}
-
-# Make and then change into directory
-# @see: https://github.com/ohmyzsh/ohmyzsh/blob/master/lib/functions.zsh#L36
-function mkcd takedir() {
-  mkdir -p $@ && cd ${@:$#}
-}
-
-# Git clone and then change into directory
-# @see: https://github.com/ohmyzsh/ohmyzsh/blob/master/lib/functions.zsh#L36
-function takegit() {
-  git clone "$1"
-  cd "$(basename ${1%%.git})"
-}
-
-# Snapshot a webpage
-# @see: https://github.com/Y2Z/monolith
-# @see: https://gist.github.com/oneohthree/f528c7ae1e701ad990e6
-function snapshot() {
-    local slug="$(echo "$1" | iconv -t ascii//TRANSLIT | sed -E -e 's/[^[:alnum:]]+/-/g' -e 's/^-+|-+$//g' | tr '[:upper:]' '[:lower:]')"
-
-    monolith --no-audio --no-frames --no-fonts --no-js --insecure --no-metadata --no-video --isolate --output="$slug.html" "$1"
+# Download a snapshot of a webpage to a single HTML file
+# @see: https://github.com/gildas-lormeau/SingleFile
+singlefile() {
+    if [ "$(command -v docker)" ]; then
+        docker run capsulecode/singlefile "$1" > "$2"
+    else
+        echo "Docker needs to be installed to run SingleFile"
+    fi   
 }

--- a/ansible/roles/shell/files/.zsh_functions
+++ b/ansible/roles/shell/files/.zsh_functions
@@ -45,17 +45,6 @@ setdns() {
     fi
 }
 
-
-# Download a snapshot of a webpage to a single HTML file
-# @see: https://github.com/gildas-lormeau/SingleFile
-singlefile() {
-    if [ "$(command -v docker)" ]; then
-        docker run capsulecode/singlefile "$1" > "$2"
-    else
-        echo "Docker needs to be installed to run SingleFile"
-    fi   
-}
-
 # Encrypt and decrypt files quickly
 function enc() {
     openssl enc -aes-256-cbc -md sha512 -pbkdf2 -iter 1000000 -salt -in "$1" -out "$1.enc"
@@ -63,13 +52,4 @@ function enc() {
 
 function dec() {
     openssl enc -d -aes-256-cbc -md sha512 -pbkdf2 -iter 1000000 -in "$1" -out "$(basename $1 .enc)"
-}
-
-# Sync 1Password 7 Vault
-function syncvault() {
-    echo "Backing up 1Password to iCloud..."
-    rsync --archive --compress --progress --verbose --quiet "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Users/Jamie/Library/Mobile Documents/com~apple~CloudDocs/1Password/"
-
-    echo "Backing up 1Password to NAS..."
-    rsync --archive --compress --progress --verbose --quiet "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Volumes/files/Backups/1Password/"
 }

--- a/ansible/roles/shell/files/.zsh_functions
+++ b/ansible/roles/shell/files/.zsh_functions
@@ -58,9 +58,10 @@ singlefile() {
 
 # Sync 1Password 7 Vault
 function syncvault() {
-    # Sync Backups to NAS:
-    rsync --recursive --times --update --compress --progress --verbose "/Users/Jamie/Library/Group Containers/2BUA8C4S2C.com.agilebits/Library/Application Support/1Password/Backups/" "/Volumes/files/Backups/1Password/Snapshots/"
-
     # Sync Dropbox to iCloud:
     rsync --archive --compress --progress --verbose "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Users/Jamie/Library/Mobile Documents/com~apple~CloudDocs/1Password/"
+
+    # Sync Backups to NAS:
+    rsync --archive --compress --progress --verbose "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Volumes/files/Backups/1Password/"
+    rsync --recursive --times --update --compress --progress --verbose "/Users/Jamie/Library/Group Containers/2BUA8C4S2C.com.agilebits/Library/Application Support/1Password/Backups/" "/Volumes/files/Backups/1Password/"
 }

--- a/ansible/roles/shell/files/.zsh_functions
+++ b/ansible/roles/shell/files/.zsh_functions
@@ -58,10 +58,9 @@ singlefile() {
 
 # Sync 1Password 7 Vault
 function syncvault() {
-    # Sync Dropbox to iCloud:
-    rsync --archive --compress --progress --verbose "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Users/Jamie/Library/Mobile Documents/com~apple~CloudDocs/1Password/"
+    echo "Backing up 1Password to iCloud..."
+    rsync --archive --compress --progress --verbose --quiet "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Users/Jamie/Library/Mobile Documents/com~apple~CloudDocs/1Password/"
 
-    # Sync Backups to NAS:
-    rsync --archive --compress --progress --verbose "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Volumes/files/Backups/1Password/Latest/"
-    rsync --recursive --times --update --compress --progress --verbose "/Users/Jamie/Library/Group Containers/2BUA8C4S2C.com.agilebits/Library/Application Support/1Password/Backups/" "/Volumes/files/Backups/1Password/Snapshots/"
+    echo "Backing up 1Password to NAS..."
+    rsync --archive --compress --progress --verbose --quiet "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Volumes/files/Backups/1Password/Latest/"
 }

--- a/ansible/roles/shell/files/.zsh_functions
+++ b/ansible/roles/shell/files/.zsh_functions
@@ -55,3 +55,12 @@ singlefile() {
         echo "Docker needs to be installed to run SingleFile"
     fi   
 }
+
+# Sync 1Password 7 Vault
+function syncvault() {
+    # Sync Backups to NAS:
+    rsync --recursive --times --update --compress --progress --verbose "/Users/Jamie/Library/Group Containers/2BUA8C4S2C.com.agilebits/Library/Application Support/1Password/Backups/" "/Volumes/files/Backups/1Password/Snapshots/"
+
+    # Sync Dropbox to iCloud:
+    rsync --archive --compress --progress --verbose "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Users/Jamie/Library/Mobile Documents/com~apple~CloudDocs/1Password/"
+}

--- a/ansible/roles/shell/files/.zsh_functions
+++ b/ansible/roles/shell/files/.zsh_functions
@@ -56,6 +56,15 @@ singlefile() {
     fi   
 }
 
+# Encrypt and decrypt files quickly
+function enc() {
+    openssl enc -aes-256-cbc -md sha512 -pbkdf2 -iter 1000000 -salt -in "$1" -out "$1.enc"
+}
+
+function dec() {
+    openssl enc -d -aes-256-cbc -md sha512 -pbkdf2 -iter 1000000 -in "$1" -out "$(basename $1 .enc)"
+}
+
 # Sync 1Password 7 Vault
 function syncvault() {
     echo "Backing up 1Password to iCloud..."

--- a/ansible/roles/shell/files/.zsh_functions
+++ b/ansible/roles/shell/files/.zsh_functions
@@ -57,14 +57,16 @@ singlefile() {
 }
 
 # Sync 1Password 7 Vault
+# Automatic Snapshots Directory: /Users/Jamie/Library/Group Containers/2BUA8C4S2C.com.agilebits/Library/Application Support/1Password/Backups
 function syncvault() {
     echo "Backing up 1Password to iCloud..."
     rsync --archive --compress --progress --verbose --quiet "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Users/Jamie/Library/Mobile Documents/com~apple~CloudDocs/1Password/"
 
     echo "Rotating 1Password on NAS..."
     mkdir -p "/Volumes/files/Backups/1Password/Backups"
-    cp --recursive --force "/Volumes/files/Backups/1Password/Latest/1Password.opvault" "/Volumes/files/Backups/1Password/Backups/1Password-$(date +%F).opvault"
+    rsync --archive --compress --progress --verbose --quiet "/Volumes/files/Backups/1Password/Latest/1Password.opvault" "/Volumes/files/Backups/1Password/Backups/1Password-$(date +%F).opvault"
 
     echo "Backing up 1Password to NAS..."
     rsync --archive --compress --progress --verbose --quiet "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Volumes/files/Backups/1Password/Latest/"
 }
+

--- a/ansible/roles/shell/files/.zsh_functions
+++ b/ansible/roles/shell/files/.zsh_functions
@@ -61,6 +61,10 @@ function syncvault() {
     echo "Backing up 1Password to iCloud..."
     rsync --archive --compress --progress --verbose --quiet "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Users/Jamie/Library/Mobile Documents/com~apple~CloudDocs/1Password/"
 
+    echo "Rotating 1Password on NAS..."
+    mkdir -p "/Volumes/files/Backups/1Password/Backups"
+    cp --recursive --force "/Volumes/files/Backups/1Password/Latest/1Password.opvault" "/Volumes/files/Backups/1Password/Backups/1Password-$(date +%F).opvault"
+
     echo "Backing up 1Password to NAS..."
     rsync --archive --compress --progress --verbose --quiet "/Users/Jamie/Dropbox/1Password/1Password.opvault" "/Volumes/files/Backups/1Password/Latest/"
 }

--- a/ansible/roles/shell/files/.zsh_paths
+++ b/ansible/roles/shell/files/.zsh_paths
@@ -1,16 +1,8 @@
 # Change Directory Path
-# https://twitter.com/paulredmond/status/1204557648026144768
-# https://thoughtbot.com/blog/cding-to-frequently-used-directories-in-zsh
+# @see: https://twitter.com/paulredmond/status/1204557648026144768
+# @see: https://thoughtbot.com/blog/cding-to-frequently-used-directories-in-zsh
 setopt auto_cd
 cdpath=($HOME/Projects)
 
 # Local Binary Path
-# export PATH="$HOME/.bin:$PATH"
-
-# Ruby Environment Path
-# export PATH="$HOME/.rbenv/bin:$PATH"
-
-# Go Path
-# export GOPATH="$HOME/Go"
-# export GOBIN="$GOPATH/bin"
-# export PATH="$(go env GOPATH)/bin:$PATH"
+export PATH="$PATH:$HOME/.bin"

--- a/ansible/roles/shell/files/.zshrc
+++ b/ansible/roles/shell/files/.zshrc
@@ -1,7 +1,7 @@
 # Homebrew configuration
 # @see: https://docs.brew.sh/Installation
 if [ "$(command -v brew)" ]; then
-    eval "$(/usr/local/bin/brew shellenv)"
+    eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
 
 # Pure theme and prompt

--- a/ansible/roles/shell/files/.zshrc
+++ b/ansible/roles/shell/files/.zshrc
@@ -1,11 +1,11 @@
 # Homebrew configuration
-# https://docs.brew.sh/Installation
+# @see: https://docs.brew.sh/Installation
 if [ "$(command -v brew)" ]; then
-    eval "$(/opt/homebrew/bin/brew shellenv)"
+    eval "$(/usr/local/bin/brew shellenv)"
 fi
 
 # Pure theme and prompt
-# https://github.com/sindresorhus/pure
+# @see: https://github.com/sindresorhus/pure
 if [ "$(command -v brew)" ]; then
     fpath+=("$(brew --prefix)/share/zsh/site-functions")
     autoload -U promptinit; promptinit
@@ -14,7 +14,7 @@ if [ "$(command -v brew)" ]; then
 fi
 
 # Auto suggestions
-# https://github.com/zsh-users/zsh-autosuggestions
+# @see: https://github.com/zsh-users/zsh-autosuggestions
 if [ -f "/usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh" ]; then
     source /usr/local/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 fi


### PR DESCRIPTION
Weird issue on macOS 12.7.1 Monteray:

```
eval "$(/usr/local/bin/brew shellenv)"

fpath+=("$(brew --prefix)/share/zsh/site-functions")
autoload -U promptinit; promptinit
prompt pure
zstyle :prompt:pure:git:stash show yes
```

```
❯ exec $SHELL -l

/Users/ziadoz/.zsh_sessions/F79A28F2-7FA9-40F8-83BA-728DD499E367.session:2: command not found: Saving
```

```
❯ cat /Users/Jamie/.zsh_sessions/F79A28F2-7FA9-40F8-83BA-728DD499E367.session

Saving session...echo Restored session: "$(/bin/date -r 1701213053)"
```

Seems to be coming from [Pure](https://github.com/sindresorhus/pure).

https://www.google.com/search?hl=en&q=%22.session%3A2%3A%20command%20not%20found%3A%20Saving
https://apple.stackexchange.com/questions/465930/apple-terminal-startup-errors-session-save-restore
https://stackoverflow.com/questions/62316487/terminal-modified-permanently-by-vscode/77424721#77424721
https://superuser.com/questions/975678/strange-output-from-terminal-exit-command-is-this-a-virus
https://unix.stackexchange.com/questions/559075/does-zsh-have-some-kind-of-diagnostic-mode
https://stackoverflow.com/questions/876239/how-to-redirect-and-append-both-standard-output-and-standard-error-to-a-file-wit
https://unix.stackexchange.com/questions/453144/functions-calling-context-in-zsh-equivalent-of-bash-caller